### PR TITLE
copied and repurposed the Piety Garden code to make it work for Tradition Finisher bug

### DIFF
--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -10255,7 +10255,6 @@ void CvCity::SetIgnoreCityForHappiness(bool bValue)
 	m_bIgnoreCityForHappiness = bValue;
 }
 
-
 /// Find the gardens ~EAP
 //	--------------------------------------------------------------------------------
 BuildingTypes CvCity::ChooseFreeGardenBuilding() const
@@ -10270,6 +10269,28 @@ BuildingTypes CvCity::ChooseFreeGardenBuilding() const
 		const BuildingClassTypes eBuildingClass = static_cast<BuildingClassTypes>(iI);
 		CvBuildingClassInfo* pkBuildingClassInfo = GC.getBuildingClassInfo(eBuildingClass);
 		if (pkBuildingClassInfo && pkBuildingClassInfo->GetType() == strGardenBuildingClass)
+		{
+			return (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(iI);
+		}
+	}
+
+	return NO_BUILDING;
+}
+/// Loupgarou - add support for (bug)Free Tradition Aqueduct on Finisher
+//---------------------------------------------------------------------------------
+/// Find the Aqueduct ~EAP ft. Loupgarou (kek)
+BuildingTypes CvCity::ChooseFreeAqueductBuilding() const
+{
+	CvString strAqueductBuildingClass = "BUILDINGCLASS_AQUEDUCT";
+#ifdef AUI_WARNING_FIXES
+	for (uint iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
+#else
+	for (int iI = 0; iI < GC.getNumBuildingClassInfos(); iI++)
+#endif
+	{
+		const BuildingClassTypes eBuildingClass = static_cast<BuildingClassTypes>(iI);
+		CvBuildingClassInfo* pkBuildingClassInfo = GC.getBuildingClassInfo(eBuildingClass);
+		if (pkBuildingClassInfo && pkBuildingClassInfo->GetType() == strAqueductBuildingClass)
 		{
 			return (BuildingTypes)getCivilizationInfo().getCivilizationBuildings(iI);
 		}

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.h
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -567,6 +567,7 @@ public:
 	
 	BuildingTypes ChooseFreeWallsBuilding() const; // NQMP GJS - Oligarchy free walls
 	BuildingTypes ChooseFreeGardenBuilding() const;
+	BuildingTypes ChooseFreeAqueductBuilding() const; // Loupgarou
 	BuildingTypes ChooseFreeCultureBuilding() const;
 	BuildingTypes ChooseFreeFoodBuilding() const;
 

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPlayer.h
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPlayer.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -417,6 +417,8 @@ public:
 	void ChangeNumCitiesFreeAestheticsSchools(int iChange); // NQMP GJS - add support for NumCitiesFreeAestheticsSchools
 	int GetNumCitiesFreePietyGardens() const;
 	void ChangeNumCitiesFreePietyGardens(int iChange); // LEKMOD - add support for Free Piety Gardens on Finisher
+	int GetNumCitiesFreeTraditionAqueduct() const; // Loupgarou - (bug)Free Tradition Aqueducts on Finisher
+	void ChangeNumCitiesFreeTraditionAqueduct(int iChange); // Loupgarou - add support for (bug)Free Tradition Aqueduct on Finisher
 	int GetNumCitiesFreeWalls() const; // NQMP GJS - New Oligarchy add support for NumCitiesFreeWalls
 	void ChangeNumCitiesFreeWalls(int iChange); // NQMP GJS - New Oligarchy add support for NumCitiesFreeWalls
 	int GetNumCitiesFreeCultureBuilding() const;
@@ -2018,6 +2020,7 @@ protected:
 	int m_iGarrisonFreeMaintenanceCount;
 	int m_iNumCitiesFreeAestheticsSchools; // NQMP GJS - add support for NumCitiesFreeAestheticsSchools
 	int m_iNumCitiesFreePietyGardens;
+	int m_iNumCitiesFreeTraditionAqueduct; // Loupgarou - (bug)Free Tradition Aqueducts on Finisher
 	int m_iNumCitiesFreeWalls; // NQMP GJS - New Oligarchy add support for NumCitiesFreeWalls
 	int m_iNumCitiesFreeCultureBuilding;
 	int m_iNumCitiesFreeFoodBuilding;

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPolicyClasses.cpp
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -231,6 +231,7 @@ CvPolicyEntry::CvPolicyEntry(void):
 #endif
 	m_iNumCitiesFreeAestheticsSchools(0), // NQMP GJS - add support for NumCitiesFreeAestheticsSchools
 	m_iNumCitiesFreePietyGardens(0),
+	m_iNumCitiesFreeTraditionAqueduct(0), // Loupgarou - (bug)Free Tradition Aqueducts on Finisher
 	m_iNumCitiesFreeWalls(0), // NQMP GJS - New Oligarchy add support for NumCitiesFreeWalls
 	m_iNumCitiesFreeCultureBuilding(0),
 	m_iNumCitiesFreeFoodBuilding(0),
@@ -454,6 +455,7 @@ bool CvPolicyEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility&
 #endif
 	m_iNumCitiesFreeAestheticsSchools = kResults.GetInt("NumCitiesFreeAestheticsSchools"); // NQMP GJS - add support for NumCitiesFreeAestheticsSchools
 	m_iNumCitiesFreePietyGardens = kResults.GetInt("NumCitiesFreePietyGardens");
+	m_iNumCitiesFreeTraditionAqueduct = kResults.GetInt("NumCitiesFreeTraditionAqueduct"); // Loupgarou - (bug)Free Tradition Aqueducts on Finisher
 	m_iNumCitiesFreeWalls = kResults.GetInt("NumCitiesFreeWalls"); // NQMP GJS - New Oligarchy add support for NumCitiesFreeWalls
 	m_iNumCitiesFreeCultureBuilding = kResults.GetInt("NumCitiesFreeCultureBuilding");
 	m_iNumCitiesFreeFoodBuilding = kResults.GetInt("NumCitiesFreeFoodBuilding");
@@ -1808,6 +1810,12 @@ int CvPolicyEntry::GetNumCitiesFreeAestheticsSchools() const
 int CvPolicyEntry::GetNumCitiesFreePietyGardens() const
 {
 	return m_iNumCitiesFreePietyGardens;
+}
+
+/// Loupgarou - add support for (bug)Free Tradition Aqueduct on Finisher
+int CvPolicyEntry::GetNumCitiesFreeTraditionAqueduct() const
+{
+	return m_iNumCitiesFreeTraditionAqueduct;
 }
 
 // NQMP GJS - New Oligarchy add support for NumCitiesFreeWalls

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPolicyClasses.h
@@ -1,5 +1,5 @@
 /*	-------------------------------------------------------------------------------------------------------
-	© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
+	Â© 1991-2012 Take-Two Interactive Software and its subsidiaries.  Developed by Firaxis Games.  
 	Sid Meier's Civilization V, Civ, Civilization, 2K Games, Firaxis Games, Take-Two Interactive Software 
 	and their respective logos are all trademarks of Take-Two interactive Software, Inc.  
 	All other marks and trademarks are the property of their respective owners.  
@@ -219,6 +219,7 @@ public:
 #endif
 	int GetNumCitiesFreeAestheticsSchools() const; // NQMP GJS - add support for NumCitiesFreeAestheticsSchools
 	int GetNumCitiesFreePietyGardens() const; // LEKMOD - Piety Gardens
+	int GetNumCitiesFreeTraditionAqueduct() const; // Loupgarou - add support for (bug)Free Tradition Aqueduct on Finisher
 	int GetNumCitiesFreeWalls() const; // NQMP GJS - New Oligarchy add support for NumCitiesFreeWalls
 	int GetNumCitiesFreeCultureBuilding() const;
 	int GetNumCitiesFreeFoodBuilding() const;
@@ -503,6 +504,7 @@ private:
 #endif
 	int m_iNumCitiesFreeAestheticsSchools; // NQMP GJS - add support for NumCitiesFreeAestheticsSchools
 	int m_iNumCitiesFreePietyGardens;
+	int m_iNumCitiesFreeTraditionAqueduct; // Loupgarou - (bug)Free Tradition Aqueducts on Finisher
 	int m_iNumCitiesFreeWalls; // NQMP GJS - New Oligarchy add support for NumCitiesFreeWalls
 	int m_iNumCitiesFreeCultureBuilding;
 	int m_iNumCitiesFreeFoodBuilding;


### PR DESCRIPTION
No longer dupes aqueducts if a civ has a UB aqueduct according to my testing, will delete the built aqueduct then give one, meaning on build effects with be given twice though

New line needed in the XML NumCitiesFreeTraditionAqueduct 4 /NumCitiesFreeTraditionAqueduct for Tradition Finisher.