### PR TITLE
fix Boer farm visual yield lag

### DIFF
--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvImprovementClasses.cpp
@@ -1234,6 +1234,35 @@ int CvImprovementEntry::GetImprovementAdjacentAmount(int i, int j) const
 	CvAssertMsg(j > -1, "Index out of bounds");
 	return m_ppiImprovementAdjacentAmount[i][j];
 }
+// New method to trigger the visual changes when nessesary
+bool CvImprovementEntry::HasAnyAdjacencyYieldBonus() const
+{
+	for (int i = 0; i < GC.getNumImprovementInfos(); ++i)
+	{
+		for (int j = 0; j < NUM_YIELD_TYPES; ++j) // Yield loop
+		{
+			if (GetImprovementAdjacentBonus(i, j) > 0)
+				return true;
+			if (GetImprovementAdjacentBonusCivilization(i, j) > 0)
+				return true;
+			if (GetImprovementAdjacentBonusCivilizationNoAmount(i, j) > 0)
+				return true;
+		}
+	}
+
+	for (int i = 0; i < NUM_YIELD_TYPES; ++i)
+	{
+		for (int j = 0; j < 6; ++j) // Civilization loop
+		{
+			if (GetImprovementAdjacentAmount(i, j) > 0)
+				return true;
+			if (GetImprovementAdjacentCivilizationAmount(i, j) > 0)
+				return true;
+		}
+	}
+
+	return false;
+}
 #endif
 /// How much a tech improves the yield of this improvement if it DOES NOT have fresh water
 int CvImprovementEntry::GetTechNoFreshWaterYieldChanges(int i, int j) const

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvImprovementClasses.h
@@ -158,6 +158,7 @@ public:
 	int GetImprovementAdjacentBonusCivilizationNoAmount(int i, int j) const;
 	int GetImprovementAdjacentBonusCivilization(int i, int j) const;
 	int GetImprovementAdjacentAmount(int i, int j) const;
+	bool HasAnyAdjacencyYieldBonus() const;
 #endif
 	int GetTechNoFreshWaterYieldChanges(int i, int j) const;
 	int* GetTechNoFreshWaterYieldChangesArray(int i);

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPlot.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPlot.cpp
@@ -6413,9 +6413,13 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 		if(eOldImprovement != NO_IMPROVEMENT)
 		{
 			CvImprovementEntry& oldImprovementEntry = *GC.getImprovementInfo(eOldImprovement);
-
+#if !defined (LEKMOD_ADJACENT_IMPROVEMENT_YIELD) // Fix visual Bug
 			// If this improvement can add culture to nearby improvements, update them as well
 			if(oldImprovementEntry.GetCultureAdjacentSameType() > 0)
+#else
+			// If this improvement can add yields to nearby improvements, update them as well
+			if (oldImprovementEntry.GetCultureAdjacentSameType() > 0 && oldImprovementEntry.HasAnyAdjacencyYieldBonus())
+#endif
 			{
 				for(iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
 				{
@@ -6523,9 +6527,13 @@ void CvPlot::setImprovementType(ImprovementTypes eNewValue, PlayerTypes eBuilder
 		if(m_eImprovementType != NO_IMPROVEMENT)
 		{
 			CvImprovementEntry& newImprovementEntry = *GC.getImprovementInfo(eNewValue);
-
+#if !defined (LEKMOD_ADJACENT_IMPROVEMENT_YIELD) // Fix visual Bug
 			// If this improvement can add culture to nearby improvements, update them as well
 			if(newImprovementEntry.GetCultureAdjacentSameType() > 0)
+#else
+			// If this improvement can add yields to nearby improvements, update them as well
+			if (newImprovementEntry.GetCultureAdjacentSameType() > 0 && newImprovementEntry.HasAnyAdjacencyYieldBonus())
+#endif
 			{
 				for(iI = 0; iI < NUM_DIRECTION_TYPES; iI++)
 				{


### PR DESCRIPTION
added 2 checks where the Moai also checks for adjacent yield changes so that the table updates yields properly for Boers. Some part of expending a great person updates yields making this not an issue for Madagascar,