### PR TITLE
Award contested wonders by hammer surplus instead of activation order

### DIFF
--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -15599,6 +15599,7 @@ bool CvCity::doCheckProduction()
 			if(iBuildingProduction > 0)
 			{
 				const BuildingClassTypes eExpiredBuildingClass = (BuildingClassTypes)(pkExpiredBuildingInfo->GetBuildingClassType());
+#ifdef LEKMOD_FAIR_WONDER_RESULTS
 				bool inContest = false;
 				bool wonderAlreadyBuilt = false;
 				PlayerTypes beatenBy = PlayerTypes::NO_PLAYER;
@@ -15671,6 +15672,12 @@ checkNextPlayer:;
 				else if(isBuildingMaxedOut && isWorldWonderClass(pkExpiredBuildingInfo->GetBuildingClassInfo()))
 				{
 					wonderAlreadyBuilt = true;
+#else
+				if (thisPlayer.isProductionMaxedBuildingClass(eExpiredBuildingClass))
+				{
+				if (isWorldWonderClass(pkExpiredBuildingInfo->GetBuildingClassInfo()))
+				{
+#endif // LEKMOD_FAIR_WONDER_RESULTS
 					for(iPlayerLoop = 0; iPlayerLoop < MAX_MAJOR_CIVS; iPlayerLoop++)
 					{
 						eLoopPlayer = (PlayerTypes) iPlayerLoop;
@@ -15678,10 +15685,15 @@ checkNextPlayer:;
 						// Found the culprit
 						if(GET_PLAYER(eLoopPlayer).getBuildingClassCount(eExpiredBuildingClass) > 0)
 						{
+#ifdef LEKMOD_FAIR_WONDER_RESULTS
 							beatenBy = eLoopPlayer;
+#else
+							GET_PLAYER(getOwner()).GetDiplomacyAI()->ChangeNumWondersBeatenTo(eLoopPlayer, 1);
+#endif
 							break;
 						}
 					}
+#ifdef LEKMOD_FAIR_WONDER_RESULTS
 				}
 				else
 				{
@@ -15694,6 +15706,7 @@ checkNextPlayer:;
 					if(beatenBy != PlayerTypes::NO_PLAYER)
 					{
 						GET_PLAYER(getOwner()).GetDiplomacyAI()->ChangeNumWondersBeatenTo(beatenBy, 1);
+#endif
 
 						auto_ptr<ICvCity1> pDllCity(new CvDllCity(this));
 						DLLUI->AddDeferredWonderCommand(WONDER_REMOVED, pDllCity.get(), (BuildingTypes) eExpiredBuilding, 0);
@@ -15719,11 +15732,13 @@ checkNextPlayer:;
 					}
 
 					m_pCityBuildings->SetBuildingProduction(eExpiredBuilding, 0);
+#ifdef LEKMOD_FAIR_WONDER_RESULTS
 					if (inContest)
 					{
 						popOrder(getOrderQueueLength() - 1, false, true);
 						bOK = false;
 					}
+#endif
 				}
 			}
 		}
@@ -15883,7 +15898,11 @@ checkNextPlayer:;
 
 	{
 		AI_PERF_FORMAT_NESTED("City-AI-perf.csv", ("CvCity::doCheckProduction_CleanupQueue, Turn %03d, %s, %s", GC.getGame().getElapsedGameTurns(), GetPlayer()->getCivilizationShortDescription(), getName().c_str()) );
+#ifdef LEKMOD_FAIR_WONDER_RESULTS
 		bOK = CleanUpQueue() && bOK;
+#else
+		bOK = CleanUpQueue();
+#endif 
 	}
 
 	return bOK;

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/_Defines.h
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/_Defines.h
@@ -947,6 +947,8 @@
 #define LEKMOD_NEW_ANCIENT_RUIN_REWARDS
 // Fixes a rare events where players could get the oxford university building for free with the legalism policy
 #define LEKMOD_NO_FREE_TEAM_WONDERS
+// Awards contested wonders to the player who invested the most hammers instead of the first to have their turn allocated
+#define LEKMOD_FAIR_WONDER_RESULTS
 
 
 /// ###############################


### PR DESCRIPTION
In addition to checking if a building already exists in `doCheckProduction` when it is a wonder, this change checks if the wonder is contested when not yet built by any civ, and if so who is projected to win at the end of the turn by comparing the projected hammer surplus of each competing city. This surplus is calculated by computing the production which would be added to the building by `doProduction` if `doCheckProduction` evaluates to `true` and the wonder remains in the order queue, and then subtracting that amount by the wonder cost.

This results in what I believe to be a more fair way to award wonders than turn activation, which is at best random, and at worst both deterministic yet immune to player influence.

I've tested the change in singleplayer with IGE and dynamic analysis via the Visual Studio debugger, and everything seems to work as expected. I have not had the opportunity to test this in a multiplayer game, but I hope I can do so within the coming weeks when I next play with my friends. Does Lek do beta releases?

If you think this change would work better as a game option I will try to add one for it. Also, if the `LEKMOD_FAIR_WONDER_RESULTS` macro is undefined the functionality should be the same, but the actual source code produced by the preprocessor will be different from vanilla. If the purpose of these preprocessor macros is to keep the game source 1:1 with vanilla when disabled let me know and I'll correct.

I hope you like the proposed change :)