### PR TITLE
Rubber AI Fix and Palmyra Buildings

### DIFF
--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvBuilderTaskingAI.cpp
@@ -1107,7 +1107,19 @@ void CvBuilderTaskingAI::AddImprovingResourcesDirectives(CvUnit* pUnit, CvPlot* 
 		{
 			continue;
 		}
-
+#if defined(LEKMOD_v34) // Moai and Brazilwoods can now connect resources, this can mess with other civs that cannot make this improvement when it comes to BuilderAI
+		// So add a check to see if we can even make the Improvement the Build Requires. if not, then continue looping.
+		CivilizationTypes eImprovementCiv = pkImprovementInfo->GetRequiredCivilization();
+		if (eImprovementCiv != NO_CIVILIZATION && eImprovementCiv != m_pPlayer->getCivilizationType())
+		{
+			continue;
+		}
+		// Check if the plot can even have this improvement. If not then continue looping.
+		if(!pPlot->canHaveImprovement(eImprovement))
+		{
+			continue;
+		}
+#endif
 		if(eImprovement == eExistingPlotImprovement)
 		{
 			if(pPlot->IsImprovementPillaged())

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -17499,7 +17499,7 @@ bool CvCity::isValidBuildingLocation(BuildingTypes eBuilding) const
 	if(pkBuildingInfo == NULL)
 		return false;
 
-#ifdef TRAITIFY
+#if defined(TRAITIFY)
 	// Get the player's traits
 	CvPlayerTraits* pPlayerTraits = GET_PLAYER(getOwner()).GetPlayerTraits();
 	BuildingClassTypes eBuildingClass = (BuildingClassTypes)GC.getBuildingInfo(eBuilding)->GetBuildingClassType();

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -1707,6 +1707,8 @@ bool CvTraitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& 
 				"WHERE TraitType = ?");
 		}
 
+		pResults->Bind(1, szTraitType);
+
 		while (pResults->Step())
 		{
 			const int BuildingClassID = pResults->GetInt(1);


### PR DESCRIPTION
Fixed AI not improving Rubber, and Palmyra BuildingTerrainRemoval not being loaded correctly. Civ specific Improvements should no longer cause issues like this rubber one.