### PR TITLE
Downgrade GA runner image to windows-2022

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
         config: [Debug, Release]
     env:
       vs_url: https://archive.org/download/vs-2008-express-w-sp-1/VS2008-Express-w-SP1.ISO
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
It looks like [last month Github updated the runner image `windows-latest` to use Windows Server 2025](https://github.com/actions/runner-images/issues/12677). For some reason, the VS2008 installation step of the CI pipeline gets stuck on Windows Server 2025. This change downgrades the image used by the pipeline to `windows-2022`.

I would try to make this work with the latest runner image, but I don't own any machine running Windows 11 (or Windows at all anymore, for that matter), so it'd be tedious to do so. [Windows Server 2022 is still fully supported by Github](https://github.com/actions/runner-images/?tab=readme-ov-file#available-images).