### PR TITLE
Bugfixes

### DIFF
--- a/LEKMOD/Lua/Civilizations/Lekmod_venice.lua
+++ b/LEKMOD/Lua/Civilizations/Lekmod_venice.lua
@@ -3,7 +3,7 @@ include("PlotIterators.lua")
 
 local this_civ = GameInfoTypes["CIVILIZATION_VENEZ"] -- This is the Civilization name for Venice
 local is_active = LekmodUtilities:is_civilization_active(this_civ)
-
+local compassTech = GameInfoTypes["TECH_COMPASS"]
 ------------------------------------------------------------------------------------------------------------------------
 -- Venice UA: Add a Trade Route at Compass
 ------------------------------------------------------------------------------------------------------------------------
@@ -13,6 +13,8 @@ function lekmod_venice_route_compass(team_id, tech_id)
 		if player:IsAlive() and player:GetTeam() == team_id and player:GetCivilizationType() == this_civ then
 			if tech_id == compassTech then
 				player:ChangeNumMiscTradeRoutes(1)
+				print("venice TR slot added, removing listener")
+				GameEvents.TeamTechResearched.Remove(lekmod_venice_route_compass)
 			end
 		end
 	end

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -813,7 +813,9 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 		ChangeJONSCulturePerTurnFromPolicies(GET_PLAYER(getOwner()).GetPlayerPolicies()->GetNumericModifier(POLICYMOD_CULTURE_FROM_GARRISON));
 #endif
 	}
-
+#if defined(TRAITIFY)
+	updateYield();
+#endif
 	AI_init();
 
 #ifdef AUI_PLAYER_FIX_VENICE_ONLY_BANS_SETTLERS_NOT_SETTLING

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -813,9 +813,6 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 		ChangeJONSCulturePerTurnFromPolicies(GET_PLAYER(getOwner()).GetPlayerPolicies()->GetNumericModifier(POLICYMOD_CULTURE_FROM_GARRISON));
 #endif
 	}
-#if defined(TRAITIFY)
-	updateYield();
-#endif
 	AI_init();
 
 #ifdef AUI_PLAYER_FIX_VENICE_ONLY_BANS_SETTLERS_NOT_SETTLING

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvCity.cpp
@@ -672,6 +672,10 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 			ChangeBaseYieldRateFromPolicies(YIELD_CULTURE, GC.getPolicyInfo(ePolicy)->GetCulturePerCity());
 #endif
 #endif
+#if defined(LEKMOD_GARRISON_YIELD_EFFECTS)
+			ChangeGarrisonYieldBonus(YIELD_CULTURE, GC.getPolicyInfo(ePolicy)->GetCulturePerGarrisonedUnit());
+			ChangeGarrisonYieldBonus(YIELD_PRODUCTION, GC.getPolicyInfo(ePolicy)->GetProductionFromGarrison());
+#endif
 		}
 	}
 
@@ -809,7 +813,9 @@ void CvCity::init(int iID, PlayerTypes eOwner, int iX, int iY, bool bBumpUnits, 
 		ChangeJONSCulturePerTurnFromPolicies(GET_PLAYER(getOwner()).GetPlayerPolicies()->GetNumericModifier(POLICYMOD_CULTURE_FROM_GARRISON));
 #endif
 	}
-
+#if defined(TRAITIFY)
+	updateYield();
+#endif
 	AI_init();
 
 #ifdef AUI_PLAYER_FIX_VENICE_ONLY_BANS_SETTLERS_NOT_SETTLING

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvMinorCivAI.cpp
@@ -655,10 +655,8 @@ bool CvMinorCivQuest::IsExpired()
 #if defined(LEKMOD_CITYSTATE_QUEST_CHANGES) // Expire Wonder quests if we are more than 1 era ahead of the wonder's era ( Classical Wonders Expire in Renaissance, etc. )
 				const TechTypes eRequiredTech = (TechTypes)pkBuildingInfo->GetPrereqAndTech();
 				const int iWonderEra = GC.getTechInfo(eRequiredTech)->GetEra();
-				if ((iWonderEra + 1) < pLoopPlayer->GetCurrentEra())
-				{
+				if ((iWonderEra + 1) < pLoopPlayer->GetCurrentEra() && m_eAssignedPlayer == eLoopPlayer) // Only expire for the assigned player
 					return true;
-				}
 #endif
 			}
 		}

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -5000,9 +5000,7 @@ void CvPlayer::doTurn()
 	{
 		doTurnPostDiplomacy();
 	}
-#if defined(TRAITIFY)
-	updateYield();
-#endif
+
 	ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
 	if(pkScriptSystem)
 	{
@@ -8714,7 +8712,9 @@ void CvPlayer::found(int iX, int iY, UnitTypes eSettlerUnit)
 		pCity->SetSettlerUnit(eSettlerUnit);
 	}
 #endif
-
+#if defined(TRAITIFY)
+	pCity->updateYield();
+#endif
 	AwardFreeBuildings(pCity);
 
 	DoUpdateNextPolicyCost();

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPlayer.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvPlayer.cpp
@@ -5000,7 +5000,9 @@ void CvPlayer::doTurn()
 	{
 		doTurnPostDiplomacy();
 	}
-
+#if defined(TRAITIFY)
+	updateYield();
+#endif
 	ICvEngineScriptSystem1* pkScriptSystem = gDLL->GetScriptSystem();
 	if(pkScriptSystem)
 	{
@@ -13326,7 +13328,7 @@ void CvPlayer::DoYieldBonusFromConversion(YieldTypes eYield, CvUnit* pConverting
 			}
 		}
 	}
-	int iTotalValue = iFollowerDelta * ((bMajority ? iPerFollower + iPerFollowerMajority : iPerFollower));
+	int iTotalValue = (iFollowerDelta * iPerFollower) + (bMajority ? iPerFollowerMajority : 0);
 	if (iTotalValue > 0)
 	{
 		switch (eYield)

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvReligionClasses.cpp
@@ -3821,7 +3821,18 @@ void CvCityReligions::DoPopulationChange(int iChange)
 	}
 	else if (iChange < 0)
 	{
+#if defined(LEKMOD_RELIGIOUS_PRESSURE_POP_LOSS) // Reduce Atheism pressure on pop loss, if it is the majority religion
+		if (eMajorityReligion == NO_RELIGION)
+		{
+			AddReligiousPressure(FOLLOWER_CHANGE_POP_CHANGE, eMajorityReligion, iChange * GC.getRELIGION_ATHEISM_PRESSURE_PER_POP());
+		}
+		else
+		{
+			RecomputeFollowers(FOLLOWER_CHANGE_POP_CHANGE, eMajorityReligion);
+		}
+#else
 		RecomputeFollowers(FOLLOWER_CHANGE_POP_CHANGE, eMajorityReligion);
+#endif
 	}
 }
 

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvTeam.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvTeam.cpp
@@ -5749,8 +5749,8 @@ void CvTeam::setHasTech(TechTypes eIndex, bool bNewValue, PlayerTypes ePlayer, b
 						{
 							if(pLoopPlot->isCity() || pLoopPlot->getImprovementType() != NO_IMPROVEMENT)
 							{
-								// Appropriate Improvement on this Plot?
-								if(pLoopPlot->isCity() || GC.getImprovementInfo(pLoopPlot->getImprovementType())->IsImprovementResourceTrade(eResource))
+								// Appropriate Unpillaged Improvement on this Plot?
+								if (pLoopPlot->isCity() || (GC.getImprovementInfo(pLoopPlot->getImprovementType())->IsImprovementResourceTrade(eResource) && !pLoopPlot->IsImprovementPillaged()))
 								{
 									for(int iI = 0; iI < MAX_PLAYERS; iI++)
 									{

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -3321,6 +3321,9 @@ void CvPlayerTraits::Reset()
 	m_bFasterInHills = false;
 	m_bEmbarkedAllWater = false;
 	m_bEmbarkedToLandFlatCost = false;
+#ifdef LEKMOD_TRAIT_CIVILIAN_EMBARK_ONE_MOVE
+	m_bCiviliansEmbarkOneMove = false;
+#endif
 	m_bNoHillsImprovementMaintenance = false;
 	m_bTechBoostFromCapitalScienceBuildings = false;
 	m_bStaysAliveZeroCities = false;

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvTraitClasses.cpp
@@ -1928,6 +1928,8 @@ bool CvTraitEntry::CacheResults(Database::Results& kResults, CvDatabaseUtility& 
 				"WHERE TraitType = ?");
 		}
 
+		pResults->Bind(1, szTraitType);
+
 		while (pResults->Step())
 		{
 			const int UnitClassID = pResults->GetInt(1);
@@ -3871,14 +3873,7 @@ bool CvPlayerTraits::IsBuildingClassRemoveRequiredTerrain(BuildingClassTypes eBu
 // Force Spawn UnitClass is Capital
 bool CvPlayerTraits::IsUnitClassForceSpawnCapital(UnitClassTypes eUnitClass)
 {
-	if (eUnitClass != NO_UNITCLASS)
-	{
-		return m_abForceSpawnCapital[eUnitClass];
-	}
-	else
-	{
-		return false;
-	}
+	return NO_UNITCLASS != eUnitClass ? m_abForceSpawnCapital[eUnitClass] : false;
 }
 // Building Cost Override (Gold Faith and Production)
 int CvPlayerTraits::GetBuildingCostOverride(BuildingTypes eBuilding, YieldTypes eYieldType)

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -10810,7 +10810,7 @@ bool CvUnit::canBuild(const CvPlot* pPlot, BuildTypes eBuild, bool bTestVisible,
 bool CvUnit::build(BuildTypes eBuild)
 {
 	VALIDATE_OBJECT
-	bool bFinished;
+	bool bFinished = false;
 
 	CvAssertMsg(eBuild < GC.getNumBuildInfos(), "Invalid Build");
 	CvPlayer& kPlayer = GET_PLAYER(getOwner());
@@ -10867,8 +10867,8 @@ bool CvUnit::build(BuildTypes eBuild)
 #endif
 
 	}
-
-	bFinished = pPlot->changeBuildProgress(eBuild, workRate(false), getOwner());
+	if (!bFinished)
+		bFinished = pPlot->changeBuildProgress(eBuild, workRate(false), getOwner());
 
 	finishMoves(); // needs to be at bottom because movesLeft() can affect workRate()...
 

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvUnit.cpp
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/CvUnit.cpp
@@ -8832,6 +8832,7 @@ bool CvUnit::DoSpreadReligion()
 			}
 
             #ifdef LEKMOD_PROMO_YIELD_FROM_CONVERSION
+            // Capture state before the spread
             int iFollowersBefore = pCity->GetCityReligions()->GetNumFollowers(eReligion);
             ReligionTypes eMajorityBefore = pCity->GetCityReligions()->GetReligiousMajority();
             #endif
@@ -8844,15 +8845,17 @@ bool CvUnit::DoSpreadReligion()
 				pCity->GetCityReligions()->AddReligiousPressure(FOLLOWER_CHANGE_MISSIONARY, eReligion, iConversionStrength, getOwner());
 			}
             #ifdef LEKMOD_PROMO_YIELD_FROM_CONVERSION
+            // Calculate the actual change after the spread
             int iFollowersAfter = pCity->GetCityReligions()->GetNumFollowers(eReligion);
             int iDeltaFollowers = std::max(0, iFollowersAfter - iFollowersBefore);
             ReligionTypes eMajorityAfter = pCity->GetCityReligions()->GetReligiousMajority();
-			if (iDeltaFollowers > 0 && getUnitInfo().IsSpreadReligion())
-			{
-				bool bOnlyMajority = (eMajorityAfter == eReligion && eMajorityBefore != eReligion);
-				CvPlayer* pConvertingPlayer = &GET_PLAYER(getOwner());
-				pConvertingPlayer->DoYieldsFromConversion(this, pCity, iDeltaFollowers, bOnlyMajority, getX(), getY(), 0);
-			}
+            
+            if (iDeltaFollowers > 0 && getUnitInfo().IsSpreadReligion())
+            {
+                bool bMajorityConversion = (eMajorityAfter == eReligion && eMajorityBefore != eReligion);
+				CvPlayer& kPlayer = GET_PLAYER(getOwner());
+				kPlayer.DoYieldsFromConversion(this, pCity, iDeltaFollowers, bMajorityConversion, getX(), getY(), 0);
+            }
             #endif
 			GetReligionData()->SetSpreadsLeft(GetReligionData()->GetSpreadsLeft() - 1);
 

--- a/LEKMOD_DLL/CvGameCoreDLL_Expansion2/_Defines.h
+++ b/LEKMOD_DLL/CvGameCoreDLL_Expansion2/_Defines.h
@@ -1143,6 +1143,11 @@ TXT_KEY_LEAGUE_OVERVIEW_MEMBER_DETAILS_TRAIT_VOTES
 #define RELIGION_PRESSURE_LUA
 // Extend the functionality of Religious Tolerance
 #define LEKMOD_RELIGIOUS_TOLERANCE_EXTENDED
+// Change the religious pressure when losing population
+#define LEKMOD_RELIGIOUS_PRESSURE_POP_LOSS
+
+
+
 // Generic define for temp changes
 #define CLEAN_UP
 // ------------------------------------------- Loup's Changes End -------------------------------------------------- \\


### PR DESCRIPTION
>Venice gets is Trade Slot at Compass again.
>Oman UU no longer can enter the ocean.
>Broadcast and Sydney Opera House no longer have doubled culture modifiers
>Phoenicia UU given via Trait should now spawn in the capital, instead of on a land plot
>Denmark Trait should no longer persist between games
>Rare situations of conquering a city with a luxury that is improved, but pillaged, while not having the tech to make the improvement will no longer result in a duplicated resource
>Rare case of oneturning an archeological dig will no longer result in the notification being unclearable, softlocking the game.
>the BuildFinished Lua event should no longer fire twice if an improvement is completed in 1 action
> Newly settled Tibet and Sumer cities will no longer have that one turn yield delay